### PR TITLE
Fix conan cgal selection and add GH Action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: build
+
+on: [push, workflow_dispatch, pull_request]
+
+jobs:
+  linux-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: lukka/get-cmake@latest
+
+      - name: Install Conan
+        id: conan
+        uses: turtlebrowser/get-conan@main
+
+      - name: Install dependencies
+        run: |
+          conan profile detect --force
+          conan install conanfile.txt --build=missing
+
+      - uses: lukka/run-cmake@v10
+        with:
+          configurePreset: conan-release
+          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER=g++-13']"
+          buildPreset: conan-release
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: t3d2map
+          path: t3d2map
+          compression-level: 9

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(t3d2map CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_BUILD_TYPE debug)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -g -O0")
 
 # Qt5 component for basic viewer

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,4 +1,5 @@
 [requires]
+cgal/5.5.3
 
 [generators]
 CMakeDeps


### PR DESCRIPTION
Having a GitHub Actions build that actually produces something makes it easier for users to figure out what's missing if things don't build locally, in this case, Ubuntu 23.10 ships too new CGAL library, and you also need g++ 13 to build.

fixes #2